### PR TITLE
Makes the module usable with browserify

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -40,4 +40,9 @@ function ws(uri, protocols, opts) {
   return instance;
 }
 
-if (WebSocket) ws.prototype = WebSocket.prototype;
+if (WebSocket) {
+  ws.prototype = WebSocket.prototype;
+  WebSocket.prototype.on = function(type,cb){
+   this["on"+type]=cb;
+  }
+}


### PR DESCRIPTION
A code like the following gets portable and works in node and browser context.

```
var WebSocketNode = require('ws');
var ws = new WebSocketNode('ws://localhost/websocket');

ws.on('open', function open() {
  ws.send('something');
});

ws.on('message', function(data, flags) {
 // ...
});
```
